### PR TITLE
Replace tightenco/collect

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 7.4, 7.3, 7.2]
+        php: [8.0, 7.4, 7.3]
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "composer/ca-bundle": "^1.2",
-        "guzzlehttp/guzzle": "^6.5 || ^7.1",
+        "guzzlehttp/guzzle": "^7.1",
         "illuminate/collections": "^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "composer/ca-bundle": "^1.2",
         "guzzlehttp/guzzle": "^6.5 || ^7.1",
-        "tightenco/collect": "^5.8 || ^6.0 || ^7.0 || ^8.0"
+        "illuminate/collections": "^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.3.3",
-        "orchestra/testbench": "^3.8 || ^4.5 || ^5.0",
-        "phpunit/phpunit": "^8.5 || ^9.0",
-        "symfony/var-dumper": "^4.3 || ^5.0",
-        "vlucas/phpdotenv": "^4.1"
+        "orchestra/testbench": "^6.0",
+        "phpunit/phpunit": "^9.0",
+        "symfony/var-dumper": "^5.0",
+        "vlucas/phpdotenv": "^5.2"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require-dev": {
         "mockery/mockery": "^1.3.3",
         "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^9.4",
         "symfony/var-dumper": "^5.0",
         "vlucas/phpdotenv": "^5.2"
     },

--- a/src/Feed.php
+++ b/src/Feed.php
@@ -2,10 +2,10 @@
 
 namespace Mvdnbrk\Kiyoh;
 
+use Illuminate\Support\Collection;
 use Mvdnbrk\Kiyoh\Resources\Company;
 use Mvdnbrk\Kiyoh\Resources\Review;
 use Mvdnbrk\Kiyoh\Support\Str;
-use Illuminate\Support\Collection;
 
 class Feed
 {

--- a/src/Feed.php
+++ b/src/Feed.php
@@ -5,7 +5,7 @@ namespace Mvdnbrk\Kiyoh;
 use Mvdnbrk\Kiyoh\Resources\Company;
 use Mvdnbrk\Kiyoh\Resources\Review;
 use Mvdnbrk\Kiyoh\Support\Str;
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 class Feed
 {
@@ -34,7 +34,7 @@ class Feed
     public $company;
 
     /**
-     * @var \Tightenco\Collect\Support\Collection
+     * @var \Illuminate\Support\Collection
      */
     public $reviews;
 

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -3,9 +3,9 @@
 namespace Mvdnbrk\Kiyoh\Tests;
 
 use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Collection;
 use Mvdnbrk\Kiyoh\Exceptions\KiyohException;
 use Mvdnbrk\Kiyoh\Feed;
-use Illuminate\Support\Collection;
 
 class FeedTest extends TestCase
 {

--- a/tests/FeedTest.php
+++ b/tests/FeedTest.php
@@ -5,7 +5,7 @@ namespace Mvdnbrk\Kiyoh\Tests;
 use GuzzleHttp\Psr7\Response;
 use Mvdnbrk\Kiyoh\Exceptions\KiyohException;
 use Mvdnbrk\Kiyoh\Feed;
-use Tightenco\Collect\Support\Collection;
+use Illuminate\Support\Collection;
 
 class FeedTest extends TestCase
 {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,7 +21,7 @@ abstract class TestCase extends Orchestra
     protected function setUp(): void
     {
         try {
-            (Dotenv::createImmutable(__DIR__.'/..'))->load();
+            (Dotenv::createUnsafeImmutable(__DIR__.'/..'))->load();
         } catch (InvalidPathException $e) {
             //
         } catch (InvalidFileException $e) {


### PR DESCRIPTION
This PR replaces the deprecated `tightenco/collect` with `illuminate/collections`.

- Requires `v8` of this package
- Dropped support for PHP 7.2