### PR TITLE
Set default rating to 0 if the key doesn't exists

### DIFF
--- a/src/Feed.php
+++ b/src/Feed.php
@@ -2,6 +2,7 @@
 
 namespace Mvdnbrk\Kiyoh;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Mvdnbrk\Kiyoh\Resources\Company;
 use Mvdnbrk\Kiyoh\Resources\Review;
@@ -152,7 +153,7 @@ class Feed
         $attributes = collect($array)->only('reviewContent')->flatten(1)->mapWithKeys(function ($item) {
             if ($key = $this->lookupReviewContentAttribute($item['questionGroup'])) {
                 return [
-                    $key => $item['rating'],
+                    $key => Arr::get($item, 'rating', 0),
                 ];
             }
 


### PR DESCRIPTION
While testing this API before usage I run after a weird issue. The website that I was testing contained reviews without a rating.  This happened when I used the withMigrated function to get older reviews. I guess back then the users could somehow submit a review without giving a rating 😄  

<img width="600" alt="image" src="https://user-images.githubusercontent.com/58821667/119543277-c734d200-bd90-11eb-9c52-aff3c31e2f6c.png">

issue - #14 
